### PR TITLE
WebSocketConnectionState.Disconnected not set

### DIFF
--- a/Shinobi.WebSockets/WebSocketClient.cs
+++ b/Shinobi.WebSockets/WebSocketClient.cs
@@ -122,8 +122,15 @@ namespace Shinobi.WebSockets
                 // Start message handling task
                 this.connectionTask = Task.Run(async () =>
                 {
-                    await this.HandleMessagesAsync(this.connectionCancellationTokenSource.Token);
-                    this.ChangeConnectionState(WebSocketConnectionState.Disconnected);
+                    try
+                    {
+                        await this.HandleMessagesAsync(this.connectionCancellationTokenSource.Token);
+                        this.ChangeConnectionState(WebSocketConnectionState.Disconnected);
+                    }
+                    catch
+                    {
+                        this.ChangeConnectionState(WebSocketConnectionState.Failed);
+                    }
                 });
             }
         }

--- a/Shinobi.WebSockets/WebSocketClient.cs
+++ b/Shinobi.WebSockets/WebSocketClient.cs
@@ -120,7 +120,11 @@ namespace Shinobi.WebSockets
                 }
 
                 // Start message handling task
-                this.connectionTask = Task.Run(async () => await this.HandleMessagesAsync(this.connectionCancellationTokenSource.Token));
+                this.connectionTask = Task.Run(async () =>
+                {
+                    await this.HandleMessagesAsync(this.connectionCancellationTokenSource.Token);
+                    this.ChangeConnectionState(WebSocketConnectionState.Disconnected);
+                });
             }
         }
 


### PR DESCRIPTION
When not using ManageConnectionAsync, WebSocketConnectionState should be set to Disconnected when the HandleMessagesAsync loop ends